### PR TITLE
Add generic .object[id] adding and referencing functionality

### DIFF
--- a/R/study.R
+++ b/R/study.R
@@ -73,6 +73,7 @@ study <- function(name = "Demo Study", ...) {
         hypotheses = list(),
         methods = list(),
         data = list(),
+        objects = list(),
         prep = list(),
         analyses = list()
       )
@@ -203,7 +204,6 @@ add_prep <- function(study, code,
   invisible(study)
 }
 
-
 #' Add Analysis
 #'
 #' Add an analysis to a study object
@@ -277,8 +277,6 @@ add_analysis <- function(study,
   invisible(study)
 }
 
-
-
 #' Add Data
 #'
 #' Add a dataset to a study object
@@ -349,6 +347,73 @@ add_data <- function(study, data = NULL, id = NULL) {
   idx <- get_idx(study, id, "data")
 
   study$data[[idx]] <- d
+
+  invisible(study)
+}
+
+#' Add Object
+#'
+#' Add an object to a study object
+#'
+#' @param study A study list object with class reg_study
+#' @param object The object as a list or path to a .rds file
+#' @param id The id for this object (index or character) if NULL, this creates a new object, if an analysis with this id already exists, it will overwrite it
+#' @return A study object with class reg_study_object
+#' @examples
+#'
+#' # load libraries
+#' library(tidyverse)
+#' library(afex)
+#'
+#' # create a dataframe
+#' df <- as_tibble(iris) %>%
+#'   mutate(Subject = seq.int(nrow(.)))
+#'
+#' # create an ANOVA model comparing petal length between flower species
+#' anova_object <- aov_ez(id = "Subject",
+#'                        dv = "Petal.Length",
+#'                        data = df,
+#'                        between = "Species",
+#'                        type = "III")
+#'
+#' # add the ANOVA model to the study
+#' mystudy <- study() %>%
+#'   add_object(anova_object$aov)
+#'
+#' @export
+#'
+add_object <- function(study, object = NULL, id = NULL) {
+  o <- list(id = id)
+
+  if (is.character(object)) {
+    if (!file.exists(object)) {
+      warning("The file ", object, " does not exist.")
+      return(invisible(study))
+    }
+
+    accepted_ext <- c("rds")
+
+    filename <- object
+    ext <- strsplit(basename(filename), split="\\.")[[1]][-1]
+    if (ext == "rds") {
+      rds <- readRDS(filename)
+      o <- c(o, rds)
+    } else {
+      warning("The ", ext, " format is not supported.\nPlease add data in one of the following formats: ", paste(accepted_ext, collapse = ", "))
+    }
+  }
+
+  o <- list(
+    id = id,
+    "@type" = "Object",
+    object = rds
+  )
+
+  class(o) <- c("reg_study_object", "list")
+
+  idx <- get_idx(study, id, "object")
+
+  study$objects[[idx]] <- o
 
   invisible(study)
 }

--- a/R/study.R
+++ b/R/study.R
@@ -396,8 +396,8 @@ add_object <- function(study, object = NULL, id = NULL) {
     filename <- object
     ext <- strsplit(basename(filename), split="\\.")[[1]][-1]
     if (ext == "rds") {
-      rds <- readRDS(filename)
-      o <- c(o, rds)
+      object <- readRDS(filename)
+      o <- c(o, object)
     } else {
       warning("The ", ext, " format is not supported.\nPlease add data in one of the following formats: ", paste(accepted_ext, collapse = ", "))
     }
@@ -406,7 +406,7 @@ add_object <- function(study, object = NULL, id = NULL) {
   o <- list(
     id = id,
     "@type" = "Object",
-    object = rds
+    object = object
   )
 
   class(o) <- c("reg_study_object", "list")

--- a/R/utils.R
+++ b/R/utils.R
@@ -159,10 +159,10 @@ make_func <- function(func, args, code, return = ".Last.value", envir = .GlobalE
 
 #' Load Params
 #'
-#' Load .data\[id\] and .data\[id\]$col references from the data
+#' Load .data\[id\], .data\[id\]$col, and .object\[id\] references from the data
 #'
 #' @param params a list of parameter names and values
-#' @param study the study object to get the data from
+#' @param study the study object to get the data and objects from
 #'
 #' @return params list
 #' @keywords internal
@@ -199,6 +199,22 @@ load_params <- function(params, study) {
 
       col <- gsub(pattern, "", params[j])
       params[[j]] <- study$data[[idx]]$data[[col]]
+    }
+  }
+
+  # replace any params equal to ".object[id]" with the object
+  pattern <- "^\\.object\\[(.+)\\]$"
+  replace_object <- grep(pattern, params)
+  if (length(replace_object)) {
+    for (j in replace_object) {
+      id <- params[[j]] %>%
+        regexpr(pattern, .) %>%
+        regmatches(params[[j]], .) %>%
+        gsub(".object[", "", ., fixed = TRUE) %>%
+        gsub("]", "", ., fixed = TRUE)
+      idx <- get_idx(study, id, "object")
+      if (length(study$objects) < idx) stop("object ", idx, " does not exist")
+      params[[j]] <- study$objects[[idx]]$object
     }
   }
 


### PR DESCRIPTION
This pull request adds a new function `add_object()`  to the scienceverse package, and makes minor changes in the `study()` and `load_params()` functions in order to make them compatible with the `add_object()` function. The purpose of the `add_object()` function is to make the scienceverse package compatible with R functions which require objects as their inputs instead of dataframes (e.g., the `TukeyHSD()` function takes a fitted model object, usually an aov fit, as its input). Objects which have been added to the study can then be referenced using ".object[id]" as an argument in the params list of the `add_analysis()` function.

This method is superior to simply plugging an object from the global environment (such as an aov model) into the params list of `add_analysis()` as it can be saved into the JSON format, and does not create strange output in the postreg .html file (simply plugging an object in will result in the params list in the html file being filled in by the first X number of values in the object, rather than the name of the object).

I've included a .R script file demonstrating this functionality in the attached .zip file.
[reprex_2.R.zip](https://github.com/scienceverse/scienceverse/files/4151087/reprex_2.R.zip)

I know you are currently in the process of making changes to the package. If this code is not in-line with the changes you are making I would recommend you adapt it to fit said changes, as this seems like the best way to make certain post-hoc tests compatible with the scienceverse.

Cheers,
Michael

